### PR TITLE
Refactor Scrapers: Playwright Locators & Smart Waits

### DIFF
--- a/backend/scrapers/airbus.py
+++ b/backend/scrapers/airbus.py
@@ -1,6 +1,8 @@
+import logging
 from playwright.async_api import async_playwright
 from config import AIRBUS_BASE_URL, INTERNSHIP_AIRBUS_SEARCH_URL
 
+logger = logging.getLogger(__name__)
 
 async def fetch_jobs():
     base_url = AIRBUS_BASE_URL
@@ -28,60 +30,82 @@ async def fetch_jobs():
         )
 
         page = await context.new_page()
-        await page.goto(url, timeout=60000)
+        await page.goto(url, timeout=60000, wait_until="networkidle")
 
         while True:
             # Wait for results on the current page
-            await page.wait_for_selector("section[data-automation-id='jobResults'] li", timeout=10000)
+            try:
+                await page.locator("section[data-automation-id='jobResults'] li").first.wait_for(timeout=10000)
+            except Exception as e:
+                logger.warning(f"Could not find any job results or page empty: {e}")
+                break
 
-            items = await page.query_selector_all("section[data-automation-id='jobResults'] li")
+            items = await page.locator("section[data-automation-id='jobResults'] li").all()
 
             for item in items:
-                # Playwright methods that do not involve network I/O (like query_selector, text_content, get_attribute) remain synchronous on the ElementHandle object
-                a_tag = await item.query_selector("a[data-automation-id='jobTitle']")
-                if not a_tag:
-                    raise ValueError("Could not find job title element (a[data-automation-id='jobTitle'])")
+                try:
+                    a_tag = item.locator("a[data-automation-id='jobTitle']")
+                    if await a_tag.count() == 0:
+                        logger.error("Could not find job title element (a[data-automation-id='jobTitle'])")
+                        continue
 
-                title = await a_tag.text_content()
-                title = title.strip()
-                if not title:
-                     raise ValueError("Job title is empty")
+                    title = await a_tag.inner_text()
+                    title = title.strip()
+                    if not title:
+                         logger.error("Job title is empty")
+                         continue
 
-                link = await a_tag.get_attribute("href")
-                if not link:
-                    raise ValueError("Job link is empty")
+                    link = await a_tag.get_attribute("href")
+                    if not link:
+                        logger.error("Job link is empty")
+                        continue
+                        
+                    if link and link.startswith("/"):
+                        link = base_url + link
+
+                    loc_el = item.locator("div[data-automation-id='locations'] dd")
+                    if await loc_el.count() == 0:
+                        logger.error("Could not find location element (div[data-automation-id='locations'] dd)")
+                        continue
                     
-                if link and link.startswith("/"):
-                    link = base_url + link
+                    location = await loc_el.inner_text()
+                    location = location.strip() if location else None
+                    if not location:
+                         logger.error("Location is empty")
+                         continue
 
-                loc_el = await item.query_selector("div[data-automation-id='locations'] dd")
-                if not loc_el:
-                    raise ValueError("Could not find location element (div[data-automation-id='locations'] dd)")
-                
-                location = await loc_el.text_content()
-                location = location.strip() if location else None
-                if not location:
-                     raise ValueError("Location is empty")
-
-
-                jobs.append({
-                    "module": "airbus",
-                    "company": "Airbus",
-                    "title": title,
-                    "link": link,
-                    "location": location,
-                })
+                    jobs.append({
+                        "module": "airbus",
+                        "company": "Airbus",
+                        "title": title,
+                        "link": link,
+                        "location": location,
+                    })
+                except Exception as e:
+                    logger.error(f"Unexpected error processing job item: {e}")
 
             # Check if "next" button is present and clickable
-            next_button = await page.query_selector("button[data-uxi-element-id='next']")
-            if next_button:
-                is_enabled = await next_button.is_enabled()
-            else:
-                is_enabled = False
+            next_button = page.locator("button[data-uxi-element-id='next']")
+            
+            if await next_button.count() > 0 and await next_button.is_enabled():
+                # Store the text of the first job title
+                first_item_title_locator = page.locator("section[data-automation-id='jobResults'] li").first.locator("a[data-automation-id='jobTitle']")
+                old_title = await first_item_title_locator.inner_text()
                 
-            if next_button and is_enabled:
                 await next_button.click()
-                await page.wait_for_timeout(2000)
+                
+                # Smart wait logic: wait until the first job title changes
+                try:
+                    await page.wait_for_function(
+                        """(oldTitle) => {
+                            const el = document.querySelector("section[data-automation-id='jobResults'] li a[data-automation-id='jobTitle']");
+                            return el && el.innerText.trim() !== oldTitle;
+                        }""",
+                        arg=old_title.strip(),
+                        timeout=10000
+                    )
+                except Exception as e:
+                    logger.warning(f"Timeout waiting for next page job titles to update: {e}")
             else:
                 break
 

--- a/backend/scrapers/ariane.py
+++ b/backend/scrapers/ariane.py
@@ -1,9 +1,11 @@
+import logging
 import httpx
 from bs4 import BeautifulSoup
 from playwright.async_api import async_playwright
 import asyncio
 from config import ARIANE_BASE_URL, INTERNSHIP_ARIANE_SPACE_SEARCH_URL, INTERNSHIP_ARIANE_GROUP_SEARCH_URL
 
+logger = logging.getLogger(__name__)
 
 async def fetch_arianespace_jobs():
     """Scrape the offers on arianespace website asynchronously (with httpx)"""
@@ -14,48 +16,59 @@ async def fetch_arianespace_jobs():
             response = await client.get(url)
             response.raise_for_status()
         except httpx.RequestError as e:
-            raise RuntimeError(f"Failed to fetch ArianeSpace jobs page: {e}")
+            logger.error(f"Failed to fetch ArianeSpace jobs page: {e}")
+            return []
 
     soup = BeautifulSoup(response.text, "html.parser")
 
     jobs_container = soup.select_one("#jobs_list_container")
+    if not jobs_container:
+        logger.error("Could not find jobs container (#jobs_list_container)")
+        return []
 
     jobs = []
     for li in jobs_container.find_all("li"):
-        a = li.find("a", href=True)
-        if not a:
-            raise ValueError("Could not find job link element (a href)")
+        try:
+            a = li.find("a", href=True)
+            if not a:
+                logger.error("Could not find job link element (a href)")
+                continue
 
-        title = a.get_text(strip=True)
-        if not title:
-            raise ValueError("Job title is empty")
+            title = a.get_text(strip=True)
+            if not title:
+                logger.error("Job title is empty")
+                continue
 
-        link = a["href"]
-        if not link:
-             raise ValueError("Job link attribute is empty")
-             
-        if not link.startswith("http"):
-            link = INTERNSHIP_ARIANE_SPACE_SEARCH_URL + link
+            link = a["href"]
+            if not link:
+                 logger.error("Job link attribute is empty")
+                 continue
+                 
+            if not link.startswith("http"):
+                link = INTERNSHIP_ARIANE_SPACE_SEARCH_URL + link
 
-        info_div = li.find("div", class_="mt-1")
-        location = None
-        if info_div:
-            spans = info_div.find_all("span")
-            if len(spans) >= 3:
-                location = spans[2].get_text(strip=True)
-            elif len(spans) >= 1:
-                location = spans[-1].get_text(strip=True)
-        
-        if not location:
-             raise ValueError("Could not find location in info_div")
+            info_div = li.find("div", class_="mt-1")
+            location = None
+            if info_div:
+                spans = info_div.find_all("span")
+                if len(spans) >= 3:
+                    location = spans[2].get_text(strip=True)
+                elif len(spans) >= 1:
+                    location = spans[-1].get_text(strip=True)
+            
+            if not location:
+                 logger.error("Could not find location in info_div")
+                 continue
 
-        jobs.append({
-            "module": "ariane",
-            "company": "Ariane",
-            "title": title,
-            "link": link,
-            "location": location,
-        })
+            jobs.append({
+                "module": "ariane",
+                "company": "Ariane",
+                "title": title,
+                "link": link,
+                "location": location,
+            })
+        except Exception as e:
+            logger.error(f"Unexpected error processing ArianeSpace job item: {e}")
 
     return jobs
 
@@ -82,57 +95,81 @@ async def fetch_arianegroup_jobs():
         )
 
         page = await context.new_page()
-        await page.goto(url, timeout=60000)
+        await page.goto(url, timeout=60000, wait_until="networkidle")
 
         while True:
-            await page.wait_for_selector("section[data-automation-id='jobResults'] li", timeout=10000)
-            items = await page.query_selector_all("section[data-automation-id='jobResults'] li")
+            try:
+                await page.locator("section[data-automation-id='jobResults'] li").first.wait_for(timeout=10000)
+            except Exception as e:
+                logger.warning(f"Could not find any job results or page empty: {e}")
+                break
+
+            items = await page.locator("section[data-automation-id='jobResults'] li").all()
 
             for item in items:
-                a_tag = await item.query_selector("a[data-automation-id='jobTitle']")
-                if not a_tag:
-                    raise ValueError("Could not find job title element (a[data-automation-id='jobTitle'])")
+                try:
+                    a_tag = item.locator("a[data-automation-id='jobTitle']")
+                    if await a_tag.count() == 0:
+                        logger.error("Could not find job title element (a[data-automation-id='jobTitle'])")
+                        continue
 
-                title = await a_tag.text_content()
-                title = title.strip()
-                if not title:
-                     raise ValueError("Job title is empty")
+                    title = await a_tag.inner_text()
+                    title = title.strip()
+                    if not title:
+                         logger.error("Job title is empty")
+                         continue
 
-                link = await a_tag.get_attribute("href")
-                if not link:
-                     raise ValueError("Job link is empty")
+                    link = await a_tag.get_attribute("href")
+                    if not link:
+                         logger.error("Job link is empty")
+                         continue
 
-                if link and link.startswith("/"):
-                    link = base_url + link
+                    if link and link.startswith("/"):
+                        link = base_url + link
 
-                loc_el = await item.query_selector("div[data-automation-id='locations'] dd")
-                if not loc_el:
-                    raise ValueError("Could not find location element (div[data-automation-id='locations'] dd)")
+                    loc_el = item.locator("div[data-automation-id='locations'] dd")
+                    if await loc_el.count() == 0:
+                        logger.error("Could not find location element (div[data-automation-id='locations'] dd)")
+                        continue
 
-                location = await loc_el.text_content()
-                location = location.strip() if location else None
-                if not location:
-                     raise ValueError("Location is empty")
+                    location = await loc_el.inner_text()
+                    location = location.strip() if location else None
+                    if not location:
+                         logger.error("Location is empty")
+                         continue
 
-                jobs.append({
-                    "module": "ariane",
-                    "company": "Ariane",
-                    "title": title,
-                    "link": link,
-                    "location": location,
-                })
+                    jobs.append({
+                        "module": "ariane",
+                        "company": "Ariane",
+                        "title": title,
+                        "link": link,
+                        "location": location,
+                    })
+                except Exception as e:
+                    logger.error(f"Unexpected error processing ArianeGroup job item: {e}")
 
             # Pagination
-            next_button = await page.query_selector("button[data-uxi-element-id='next']")
+            next_button = page.locator("button[data-uxi-element-id='next']")
             
-            if next_button:
-                is_enabled = await next_button.is_enabled()
-            else:
-                is_enabled = False
-
-            if next_button and is_enabled:
+            if await next_button.count() > 0 and await next_button.is_enabled():
+                # Store the text of the first job title
+                first_item_title_locator = page.locator("section[data-automation-id='jobResults'] li").first.locator("a[data-automation-id='jobTitle']")
+                old_title = await first_item_title_locator.inner_text()
+                
                 await next_button.click()
-                await page.wait_for_timeout(2000)
+                
+                # Smart wait logic: wait until the first job title changes
+                try:
+                    await page.wait_for_function(
+                        """(oldTitle) => {
+                            const el = document.querySelector("section[data-automation-id='jobResults'] li a[data-automation-id='jobTitle']");
+                            return el && el.innerText.trim() !== oldTitle;
+                        }""",
+                        arg=old_title.strip(),
+                        timeout=10000
+                    )
+                except Exception as e:
+                    logger.warning(f"Timeout waiting for next page job titles to update: {e}")
             else:
                 break
 
@@ -155,20 +192,17 @@ async def fetch_jobs():
     # return_exceptions=True allows to continue if one of the scrapers fails
     results = await asyncio.gather(*tasks, return_exceptions=True)
     
-    # Process the results
     success = False
-    
     for result in results:
         if isinstance(result, Exception):
             # Display the warning and continue
-            print(f"[WARN] Ariane fetch failed: {result}")
+            logger.warning(f"Ariane fetch failed: {result}")
         else:
             # Success: 'result' is a list of jobs
             all_jobs.extend(result)
             success = True
 
     if not success:
-        # If both scrapers failed
-        raise RuntimeError("No jobs found on either ArianeSpace or ArianeGroup pages")
+        logger.error("No jobs found on either ArianeSpace or ArianeGroup pages")
 
     return all_jobs

--- a/backend/scrapers/cnes.py
+++ b/backend/scrapers/cnes.py
@@ -1,7 +1,8 @@
+import logging
 from playwright.async_api import async_playwright
 from config import INTERNSHIP_CNES_SEARCH_URL, CNES_BASE_URL
 
-
+logger = logging.getLogger(__name__)
 
 async def fetch_jobs():
     url = INTERNSHIP_CNES_SEARCH_URL
@@ -28,50 +29,72 @@ async def fetch_jobs():
         )
 
         page = await context.new_page()
-        await page.goto(url, timeout=60000)
+        await page.goto(url, timeout=60000, wait_until="domcontentloaded")
+        
+        # Dismiss any popup by clicking elsewhere on the page
+        await page.mouse.click(10, 10)
+        
+        # Small wait to allow the popup to close and main content to be interactable
+        try:
+            await page.wait_for_timeout(1000)
+        except:
+            pass
 
-        await page.wait_for_selector("div.card.job-ad-card", timeout=10000)
+        try:
+            await page.locator("div.card.job-ad-card").first.wait_for(timeout=10000)
+        except Exception as e:
+             logger.warning(f"Could not find any job results or page empty: {e}")
+             await browser.close()
+             return jobs
 
-        cards = await page.query_selector_all("div.card.job-ad-card")
+        cards = await page.locator("div.card.job-ad-card").all()
 
         for card in cards:
-            link_tag = await card.query_selector("a.job-ad-card__link")
-            if not link_tag:
-                raise ValueError("Could not find job link element (a.job-ad-card__link)")
+            try:
+                link_tag = card.locator("a.job-ad-card__link")
+                if await link_tag.count() == 0:
+                    logger.error("Could not find job link element (a.job-ad-card__link)")
+                    continue
 
-            link = await link_tag.get_attribute("href")
-            if not link:
-                 raise ValueError("Job link is empty")
-                 
-            if link and link.startswith("/"):
-                link = CNES_BASE_URL + link
+                link = await link_tag.get_attribute("href")
+                if not link:
+                     logger.error("Job link is empty")
+                     continue
+                     
+                if link and link.startswith("/"):
+                    link = CNES_BASE_URL + link
 
-            title_el = await card.query_selector("h4.job-ad-card__description-title")
-            if not title_el:
-                 raise ValueError("Could not find job title element (h4.job-ad-card__description-title)")
-                 
-            title = await title_el.text_content()
-            title = title.strip() if title else None
-            if not title:
-                 raise ValueError("Job title is empty")
+                title_el = card.locator("h4.job-ad-card__description-title")
+                if await title_el.count() == 0:
+                     logger.error("Could not find job title element (h4.job-ad-card__description-title)")
+                     continue
+                     
+                title = await title_el.inner_text()
+                title = title.strip() if title else None
+                if not title:
+                     logger.error("Job title is empty")
+                     continue
 
-            # Footer : localisation, contrat, domaine
-            footer_items = await card.query_selector_all("ul.job-ad-card__description__footer li")
-            location = None
-            if len(footer_items) >= 1:
-                location = await footer_items[0].text_content()
-                location = location.strip()
-            
-            if not location:
-                 raise ValueError("Location not found in footer items")
+                # Footer : localisation, contrat, domaine
+                footer_items = await card.locator("ul.job-ad-card__description__footer li").all()
+                location = None
+                if len(footer_items) >= 1:
+                    location = await footer_items[0].inner_text()
+                    location = location.strip()
+                
+                if not location:
+                     logger.error("Location not found in footer items")
+                     continue
 
-            jobs.append({
-                "module": "cnes",
-                "company": "CNES",
-                "title": title,
-                "link": link,
-                "location": location,
-            })
+                jobs.append({
+                    "module": "cnes",
+                    "company": "CNES",
+                    "title": title,
+                    "link": link,
+                    "location": location,
+                })
+            except Exception as e:
+                 logger.error(f"Unexpected error processing job item: {e}")
 
         await browser.close()
 

--- a/backend/scrapers/thales.py
+++ b/backend/scrapers/thales.py
@@ -1,7 +1,8 @@
-from playwright.async_api import async_playwright, TimeoutError
+import logging
+from playwright.async_api import async_playwright
 from config import INTERNSHIP_THALES_SEARCH_URL
 
-
+logger = logging.getLogger(__name__)
 
 async def fetch_jobs():
     url = INTERNSHIP_THALES_SEARCH_URL
@@ -28,21 +29,17 @@ async def fetch_jobs():
         )
 
         page = await context.new_page() 
-        await page.goto(url, timeout=60000) 
+        await page.goto(url, timeout=60000, wait_until="networkidle") 
         
         # --- Cookies handling ---
-        # NOTE: We're using locator to get an object that supports wait_for.
         cookie_locator = page.locator("button[data-ph-at-id='cookie-close-link'] >> text=Accepter") 
         
         # Check if the element is visible and wait for it to be hidden
-        is_visible = await cookie_locator.is_visible() 
-            
-        if is_visible:
+        if await cookie_locator.is_visible(): 
             await cookie_locator.click(force=True)
-            
             try:
                 await cookie_locator.wait_for(state='hidden', timeout=5000) 
-            except TimeoutError:
+            except Exception:
                 # Keep going if the banner doesn't disappear, but the click has happened
                 pass
         # ---------------------------
@@ -50,53 +47,87 @@ async def fetch_jobs():
         while True:
             # Wait for the list to load
             try:
-                await page.wait_for_selector("li.jobs-list-item", timeout=10000) 
-            except TimeoutError:
+                await page.locator("li.jobs-list-item").first.wait_for(timeout=10000) 
+            except Exception as e:
+                logger.warning(f"Could not find any job results or timeout: {e}")
                 break 
 
-            items = await page.query_selector_all("li.jobs-list-item") 
+            items = await page.locator("li.jobs-list-item").all() 
             for item in items:
-                a_tag = await item.query_selector("a[data-ph-at-id='job-link']") 
-                if not a_tag:
-                    raise ValueError("Could not find job link element (a[data-ph-at-id='job-link'])")
+                try:
+                    a_tag = item.locator("a[data-ph-at-id='job-link']") 
+                    if await a_tag.count() == 0:
+                        logger.error("Could not find job link element (a[data-ph-at-id='job-link'])")
+                        continue
 
-                title = await a_tag.get_attribute("data-ph-at-job-title-text") 
-                if not title:
-                    title = await a_tag.inner_text() 
-                    title = title.strip()
-                
-                if not title:
-                     raise ValueError("Job title is empty")
+                    title = await a_tag.get_attribute("data-ph-at-job-title-text") 
+                    if not title:
+                        title = await a_tag.inner_text() 
+                        title = title.strip()
                     
-                link = await a_tag.get_attribute("href") 
-                if not link:
-                     raise ValueError("Job link is empty")
+                    if not title:
+                         logger.error("Job title is empty")
+                         continue
+                        
+                    link = await a_tag.get_attribute("href") 
+                    if not link:
+                         logger.error("Job link is empty")
+                         continue
 
-                location_el = await item.query_selector("span.workLocation") 
-                if not location_el:
-                     raise ValueError("Could not find location element (span.workLocation)")
-                
-                location = await location_el.text_content()
-                location = location.strip() if location else None
-                
-                if not location:
-                     raise ValueError("Location is empty")
+                    location_el = item.locator("span.workLocation") 
+                    if await location_el.count() == 0:
+                         logger.error("Could not find location element (span.workLocation)")
+                         continue
+                    
+                    location = await location_el.inner_text()
+                    location = location.strip() if location else None
+                    
+                    if not location:
+                         logger.error("Location is empty")
+                         continue
 
-                jobs.append({
-                    "module": "thales",
-                    "company": "Thales",
-                    "title": title,
-                    "link": link,
-                    "location": location,
-                })
+                    jobs.append({
+                        "module": "thales",
+                        "company": "Thales",
+                        "title": title,
+                        "link": link,
+                        "location": location,
+                    })
+                except Exception as e:
+                    logger.error(f"Unexpected error processing job item: {e}")
 
             next_button_locator = page.locator("a.next-btn[aria-label='Voir la page suivante']")
             
-            is_visible = await next_button_locator.is_visible()
-            
-            if is_visible:
+            if await next_button_locator.is_visible():
+                first_item_title_locator = page.locator("li.jobs-list-item").first.locator("a[data-ph-at-id='job-link']")
+                old_title = await first_item_title_locator.get_attribute("data-ph-at-job-title-text")
+                if not old_title:
+                    old_title = await first_item_title_locator.inner_text()
+                
                 await next_button_locator.click(force=True)
-                await page.wait_for_timeout(2000)
+                
+                # Smart wait logic: wait until the first job title changes
+                try:
+                    await page.wait_for_function(
+                        """(oldTitle) => {
+                            const el = document.querySelector("li.jobs-list-item a[data-ph-at-id='job-link']");
+                            if (!el) return false;
+                            
+                            // Check attribute first, then innerText
+                            let currentTitle = el.getAttribute('data-ph-at-job-title-text');
+                            if (!currentTitle) {
+                                currentTitle = el.innerText.trim();
+                            } else {
+                                currentTitle = currentTitle.trim();
+                            }
+                            
+                            return currentTitle !== oldTitle;
+                        }""",
+                        arg=old_title.strip() if old_title else "",
+                        timeout=10000
+                    )
+                except Exception as e:
+                    logger.warning(f"Timeout waiting for next page job titles to update: {e}")
             else:
                 break 
 


### PR DESCRIPTION
## Description

This PR introduces important stability and performance updates to the Playwright scraping architectures for Airbus, Ariane, CNES, and Thales. These enhancements aim to resolve intermittent timeouts, improve parsing robustness on modern SPAs (Single Page Applications like Workday), and increase runtime reliability without slowing down the initial loads.

## Summary of Changes

*   **Modern Playwright Locators**: Stripped away brittle `ElementHandle` and `query_selector` methods in favor of `page.locator().all()`, `.inner_text()`, and `.get_attribute()`.
*   **Granular Error Handling via Logging**: Switched away from hard-crashing `ValueError` exceptions on bad DOM nodes. Introduced the `logging` module alongside item-level `try-except` blocks. If a single job listing is malformed, it just logs a warning and continues parsing the rest of the stack.
*   **Smart Wait Pagination Logic**: Replaced static, arbitrary `wait_for_timeout` delays (e.g., waiting 2 seconds after clicking "Next"). The scrapers now evaluate the DOM and use `page.wait_for_function` to actively poll and immediately resume as soon as the client finishes fetching and rendering the new job titles for the next page.
*   **Optimized Network Contexts & Explicit Popups**:  
    *   Target endpoints now initialize with `wait_until="networkidle"` ensuring full JS loading before selectors fire. 
    *   *CNES Specific*: Reverted back from strict `networkidle` (due to background polling) and explicitly scripted a layout-safe programmatic mouse click to instantly dismiss overlapping splash/cookie banners, fixing the 60,000ms Playwright timeout bug.
    *   *Thales Specific*: Hardened explicit waits behind the Thales cookie banner.

## Affected Files
*   [backend/scrapers/airbus.py](file:///Users/abdallahnassur/dev/projects/InternApp/backend/scrapers/airbus.py)
*   [backend/scrapers/ariane.py](file:///Users/abdallahnassur/dev/projects/InternApp/backend/scrapers/ariane.py)
*   [backend/scrapers/cnes.py](file:///Users/abdallahnassur/dev/projects/InternApp/backend/scrapers/cnes.py)
*   [backend/scrapers/thales.py](file:///Users/abdallahnassur/dev/projects/InternApp/backend/scrapers/thales.py)